### PR TITLE
Increase confidence necessary to fail startup_time

### DIFF
--- a/src/plugins.py
+++ b/src/plugins.py
@@ -252,7 +252,7 @@ def startup_time(ticket, loops=5, total_samples=30, **kwds):
         if not confidence_intervals:
             print "No statistically significant difference."
         for confidence, lower_bound, in confidence_intervals:
-            if increased and confidence >= .9 and lower_bound >= .001:
+            if increased and confidence >= .999 and lower_bound >= .001:
                 status = PluginResult.Failed
             # Print 99.999x%.
             confidence = 1 - float(("%0.1g" if confidence > .9 else "%0.2g") % (1 - confidence))


### PR DESCRIPTION
90% is way too low, that means one out of 10 patchbot startups fails. I increased it to 99.9%. Thats still not enough to raise an eyebrow in particle physics ;-)
