### PR TITLE
new option "extra_trusted_authors"

### DIFF
--- a/src/patchbot.py
+++ b/src/patchbot.py
@@ -446,8 +446,8 @@ class Patchbot:
         except AttributeError:
             self.write_log("Getting trusted author list...", LOG_MAIN)
             trusted = self.load_json_from_server("trusted", retry=10).keys()
-            trusted += ['git', 'vbraun_spam']
-            self._default_trusted = trusted
+            trusted += [u'git', u'vbraun_spam']
+            self._default_trusted = set(trusted)
             return self._default_trusted
 
     def lookup_ticket(self, id, verbose=False):
@@ -530,6 +530,8 @@ class Patchbot:
 
         if "trusted_authors" not in conf:
             conf["trusted_authors"] = self.default_trusted_authors()
+        if "extra_trusted_authors" in conf:
+            conf["trusted_authors"].update(conf["extra_trusted_authors"])
 
         def locate_plugin(name):
             ix = name.rindex('.')
@@ -731,7 +733,7 @@ class Patchbot:
                         except (ValueError,subprocess.CalledProcessError):
                             # report['git_base'] not in our repo
                             self.write_log('  commit {} not in the local git repository'.format(report['git_base']),
-                                           logfile)
+                                           logfile, date=False)
                             only_in_base = -1
                         rating += bonus['behind'] * only_in_base
                     self.write_log('  rating {} after behind'.format(rating),


### PR DESCRIPTION
Hello,

1 - I propose a new option extra_trusted_authors that allows to add some extra users as trusted. The current list of untrusted users that I have is: ["DanielRecoskie", "Fougeroc", "Jayant", "JoalHeagney", "Kehengsite", "Loufer", "MariaMonks", "MatthieuDien", "Rajesh_Veeranki", "Shashank", "Vincent.Neri", "adsmith", "ajeeshr", "alexc", "amitjamadagni", "andrewsilver", "andyasb", "bern4rd", "boulier", "boussica", "bruce", "bruno", "bsinclai", "buck", "captaintrunky", "cheuberg", "csar", "cyril.banderier", "deneufchatel", "dlucas", "duenez", "egourgoulhon", "emassop", "foosterhof", "garver15", "gjorgenson", "haochen_uw", "imarquez", "isuruf", "jakobkroeker", "jan.wabbersen", "jcampbell", "jclaas", "jdefaria", "jipilab", "jj", "jmantysalo", "jondo", "jpswanson", "kdilks", "ketzu", "ljpk", "loruenser", "mantepse", "mclean", "mhs", "mkamalakshya", "mkoeppe", "mneururer", "moritz", "ncryan", "nmsirolli", "opechenik", "parisse", "patxiku", "peterwicksstringfield", "philwilt", "pluschny", "robert_dodier", "sanvila", "sbesnier", "schymans", "sg.sourav", "sjg10", "skropf", "slelievre", "stassev", "tevinjoseph", "tnv", "vinceknight", "virmaux", "vripoll", "wluebbe", "yzh"]

2 - As trusted_authors is only meant to be consulted, I set it as a set rather than as a list.