### PR TITLE
Allow disabling free space check

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -1374,7 +1374,8 @@ def main(args):
                            " '12345,19876'")
     parser.add_option("--free_giga", dest="free_giga",
                       default=4,
-                      help="number of required free gigabytes"
+                      help="number of required free gigabytes (0 means "
+                           "no minimum space required)"
                       )
 
     # options that are passed to the patchbot via the class "options"
@@ -1419,7 +1420,10 @@ def main(args):
 
     if options.sage_root == os.environ.get('SAGE_ROOT'):
         print("WARNING: Do not use this copy of sage while the patchbot is running.")
-    ensure_free_space(options.sage_root, N=options.free_giga)
+
+
+    if options.free_giga > 0:
+        ensure_free_space(options.sage_root, N=options.free_giga)
 
     if conf['use_ccache']:
         do_or_die("'%s'/sage -i ccache" %

--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -1373,7 +1373,7 @@ def main(args):
                       help="test only a list of tickets, for example"
                            " '12345,19876'")
     parser.add_option("--free_giga", dest="free_giga",
-                      default=4,
+                      type="float", default=4,
                       help="number of required free gigabytes (0 means "
                            "no minimum space required)"
                       )

--- a/sage_patchbot/util.py
+++ b/sage_patchbot/util.py
@@ -246,9 +246,9 @@ def ensure_free_space(path, N=4):
     """
     stats = os.statvfs(path)
     free = stats.f_bfree * stats.f_frsize
-    if stats.f_bfree * stats.f_frsize < (N << 30):
-        msg = "Refusing to build with less than {}G free ({} bytes "
-        msg += "available on {})"
+    if stats.f_bfree * stats.f_frsize < (N * 2**30):
+        msg = ("Refusing to build with less than {:.2f}G free ({} bytes "
+               "available on {})")
         raise ConfigException(msg.format(N, free, path))
 
 


### PR DESCRIPTION
There was not yet actually a way to disable the needed free space check.  I kept the default setting for now, but made it so that setting it to zero disables the check.  This is needed for the patchbot container.

While I was there I noticed it doesn't necessarily convert correctly to `int`, but while I was at it made it so it can be a `float` value too.