### PR TITLE
Update patchbot.py

### DIFF
--- a/sage_patchbot/patchbot.py
+++ b/sage_patchbot/patchbot.py
@@ -1338,7 +1338,7 @@ class Patchbot(object):
         return git_commit(self.sage_root, branch)
 
 
-def main(args):
+def main(args=None):
     """
     Most configuration is done in the json config file, which is
     reread between each ticket for live configuration of the patchbot.


### PR DESCRIPTION
For the console_scripts entry-point to work, main() can't require any positional arguments.  Settings `args=None` by default is fine since as a default `OptionParser.parse_args` will use `sys.argv` if passed `None`.