### PR TITLE
.github/workflows/run_patchbot.yml: Use 'dev' as default Docker tag

### DIFF
--- a/.github/workflows/run_patchbot.yml
+++ b/.github/workflows/run_patchbot.yml
@@ -11,7 +11,7 @@ on:
       docker_tag:
         description: 'Docker tag'
         required: true
-        default: '9.5'
+        default: 'dev'
       patchbot_ticket:
         description: 'Tickets to test (e.g., 12345,23456)'
         required: false


### PR DESCRIPTION
This tag is available since 9.6.beta1 - https://wiki.sagemath.org/ReleaseTours/sage-9.6#Pre-built_Docker_containers_on_ghcr.io